### PR TITLE
Fix CORS test HTTP headers are non casesensitive

### DIFF
--- a/implementations/validator/iiif_validator/tests/cors.py
+++ b/implementations/validator/iiif_validator/tests/cors.py
@@ -9,6 +9,9 @@ class Test_Cors(BaseTest):
 
     def run(self, result):
         info = result.get_info();
-        cors = result.last_headers.get('access-control-allow-origin', '')
+        cors = ''
+        for k,v in result.last_headers:
+            if k.lower() == 'access-control-allow-origin':
+                cors = v
         self.validationInfo.check('CORS', cors, '*', result)
         return result


### PR DESCRIPTION
The validator is failing if the server follows the spec.

> Servers **should** send the `Access-Control-Allow-Origin` header with the value `*` in response to information requests. The syntax is shown below and is described in the CORS specification. This header is required in order to allow the JSON responses to be used by Web applications hosted on different servers.
>
>     Access-Control-Allow-Origin: *
>
> http://iiif.io/api/image/2.1/#image-information-request